### PR TITLE
Updated Firmware/Platform team's working plan

### DIFF
--- a/doc/Platform/FirmwareTeamWorkingPlan.md
+++ b/doc/Platform/FirmwareTeamWorkingPlan.md
@@ -1,4 +1,4 @@
-# Firmware Team Member Roles:
+# Firmware / Platform Team Member Roles:
 
 - **Communications Focal**: Sloan
 - **Participation Focal**: Dara, Phoebe
@@ -6,4 +6,8 @@
 - **Product Focal**: Alexa, Rithvik
 - **Engagement Focal**: Alex
 
-The firmware team has created a group chat on iMessage for communication amongst members, as well as a Google Document to keep track of notes for meetings and firmware work progress. 
+**Communication systems**: The firmware team has created a group chat on iMessage for communication amongst members, as well as a Google Document to keep track of notes for meetings and firmware work progress. 
+**If a team member can't show up to a club meeting**: They can keep up with the content outlined in the team's Google document. Also check Discord consistently (highly recommended) for more information.
+**Amount of time expected to commit towards this team/club**: Currently, we are expecting to only work within the Wednesday & Thursday 7pm-8pm club meetings, but working additional hours outside of meeting times is optional. Team members are more than welcome to do independent research and relay their findings to the team through the firmware/platform team's Google Document.
+
+The above policy is subject to change as Firmware/Platform team members progress through the project.


### PR DESCRIPTION
# Description of Changes:
## Improvements to the MLClassifier project [10/30/25]
- Updated the "FirmwareTeamWorkingPlan.md" (markdown) file within the "Platform" folder to include additional information regarding team member's project contribution expectations.

# What's Next:
- We aim to create a new file within the **Platform** project's folder to document a working plan focused on our project's responsibilities, which includes the hardware research findings we've done during [10/30/25] club meeting *(in other words, we've so far we've gathered this information in our shared google document, and will aim to relay this info in a new/separate file within our project's folder that is accessible for all contributors to see in this GitHub MLClassifier project)*.
